### PR TITLE
Make use of Python 3 explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run
 ```
 python soas.py <syntax> [-o <output>]
 ```
-with `<syntax>` as a path to a syntax file (examples given in `gen/ex`, e.g. `python soas.py gen/ex/lambda/stlc`). By default the generated Agda modules will be saved in the `out` directory, but this can be customised with the `-o` argument.
+with `<syntax>` as a path to a syntax file (examples given in `gen/ex`, e.g. `python soas.py gen/ex/lambda/stlc`). This assumes `python` is Python 3. By default the generated Agda modules will be saved in the `out` directory, but this can be customised with the `-o` argument.
 
 * [Introduction](#introduction)
 * [Usage](#usage)

--- a/soas.py
+++ b/soas.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 from string import Template
 import os


### PR DESCRIPTION
It took me a while to figure out why the default instructions were not working for me. On macOS, `python` is linked to Python 2 by default.